### PR TITLE
fix mean to ignore nans

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -27,4 +27,4 @@ clustMethod: "complete"
 
 # demographic pattern if using logistic demography
 # options: constant, growth, decay, cycle, chaos, custom
-demography: "growth"
+demography: "decay"

--- a/src/s00_make_param_table.R
+++ b/src/s00_make_param_table.R
@@ -67,25 +67,25 @@ if(demography == "constant"){
 
 if(demography == "growth"){
   params$r = runif(K, min = 0, max = 0.5)
-  params$K = params$N*runif(K, min = 1.01, max = 2)
+  params$K = round(params$N*runif(K, min = 1.01, max = 2))
   params$custom_demography = 0
 }
 
 if(demography == "decay"){
   params$r = runif(K, min = 0, max = 0.5)
-  params$K = params$N*runif(K, min = 0.5, max = 0.99)
+  params$K = round(params$N*runif(K, min = 0.5, max = 0.99))
   params$custom_demography = 0
 }
 
 if(demography == "cycle"){
   params$r = runif(K, min = 2, max = sqrt(6))
-  params$K = params$N*runif(K, min = 0.8, max = 1.2) 
+  params$K = round(params$N*runif(K, min = 0.8, max = 1.2))
   params$custom_demography = 0
 }
 
 if(demography == "chaos"){
   params$r = runif(K, min = sqrt(6), max = 3)
-  params$K = params$N*runif(K, min = 0.8, max = 1.2)
+  params$K = round(params$N*runif(K, min = 0.8, max = 1.2))
   params$custom_demography = 0
 }
 

--- a/src/s03_PCA.Rmd
+++ b/src/s03_PCA.Rmd
@@ -18,6 +18,8 @@ library(abc)
 library(ggpubr)
 
 today = Sys.Date()
+
+my_path = "/mnt/scratch/robe1195/Josephs_Lab_Projects/outcrossing_growth/selection-demography-cnn/"
 ```
 
 # plotting functions
@@ -104,21 +106,22 @@ compare_predictions_truth_scatter = function(predictions, truth, model_labels, t
 
 # load data
 ```{r}
+
 # simulation parameters
-params = read.table("/mnt/scratch/robe1195/Josephs_Lab_Projects/selection-demography-cnn/config/parameters.tsv", sep = "\t", header = T)
+params = read.table(paste(my_path, "config/parameters.tsv", sep = ""), sep = "\t", header = T)
 
 # merge in fixation times
-fix_times = read.table("/mnt/scratch/robe1195/Josephs_Lab_Projects/selection-demography-cnn/workflow/fixation_times.txt", col.names = c("ID", "tf"))
+fix_times = read.table(paste(my_path, "workflow/fixation_times.txt", sep = ""), col.names = c("ID", "tf"))
 
 params = merge(params, fix_times, by = "ID")
 
 # merge in sweep ages
-sweep_ages = read.table("/mnt/scratch/robe1195/Josephs_Lab_Projects/selection-demography-cnn/workflow/sweep_ages.txt", col.names = c("ID", "ta")) 
+sweep_ages = read.table(paste(my_path, "workflow/sweep_ages.txt", sep = ""), col.names = c("ID", "ta")) 
 
 params = merge(params, sweep_ages, by = "ID")
 
 # add in selective sweep statistics
-sweep_stats_files = list.files(path = "/mnt/scratch/robe1195/Josephs_Lab_Projects/selection-demography-cnn/workflow/data/sweep_stats", pattern = "*.tsv", full.names = T)
+sweep_stats_files = list.files(path = paste(my_path, "workflow/data/sweep_stats", sep = ""), pattern = "*.tsv", full.names = T)
 
 sweep_stats = suppressWarnings(lapply(sweep_stats_files, read.table, header = F))
 
@@ -131,10 +134,10 @@ sweep_stats$ID = as.numeric(gsub(".tsv", "", gsub(".*sweep_stats/", "",sweep_sta
 params = merge(params, sweep_stats, by = "ID")
 
 # get simulation outputs
-mypics = list.files("/mnt/scratch/robe1195/Josephs_Lab_Projects/selection-demography-cnn/workflow/data/images", full.names = T)
+mypics = list.files(paste(my_path, "workflow/data/images", sep= ""), full.names = T)
 
 # get sim ids
-picids = as.integer(gsub(".png", "", gsub("/mnt/scratch/robe1195/Josephs_Lab_Projects/selection-demography-cnn/workflow/data/images/slim_", "", mypics)))
+picids = as.integer(gsub(".png", "", gsub(paste(my_path, "workflow/data/images/slim_", sep = ""), "", mypics)))
 
 # only keep simulations that have images
 params = params[(params$ID %in% picids),]
@@ -173,30 +176,56 @@ ggplot(params, aes(x = log10(tf + ta), y = log10(pi))) +
   theme(text = element_text(size = 20)) +
   labs(x = "log10(fixation time + sweep age)", y = "Nucleotide diversity")
 
-ggplot(params, aes(x = log10(tf), y = log10(ta), color = log10(pi))) +
+ggplot(params, aes(x = log10(tf + ta), y = num_haplos)) +
   geom_point() +
   theme_classic()
 
-ggplot(params, aes(x = tf, y = ta, color = num_haplos)) +
+ggplot(params, aes(x = log10(tf + ta), y = omega)) +
   geom_point() +
   theme_classic()
 
-ggplot(params, aes(x = tf, y = ta, color = omega)) +
+ggplot(params, aes(x = log10(tf + ta), y = zns)) +
   geom_point() +
   theme_classic()
 
-ggplot(params, aes(x = tf, y = ta, color = zns)) +
+ggplot(params, aes(x = log10(tf + ta), y = gkl_var)) +
   geom_point() +
   theme_classic()
 
-ggplot(params, aes(x = tf, y = ta, color = gkl_var)) +
+ggplot(params, aes(x = log10(tf + ta), y = gkl_skew)) +
   geom_point() +
   theme_classic()
 
-ggplot(params, aes(x = tf, y = ta, color = h123)) +
+ggplot(params, aes(x = log10(tf + ta), y = gkl_kurt)) +
   geom_point() +
   theme_classic()
 
+ggplot(params, aes(x = log10(tf + ta), y = h1)) +
+  geom_point() +
+  theme_classic()
+
+ggplot(params, aes(x = log10(tf + ta), y = h2)) +
+  geom_point() +
+  theme_classic()
+
+ggplot(params, aes(x = log10(tf + ta), y = h12)) +
+  geom_point() +
+  theme_classic()
+
+ggplot(params, aes(x = log10(tf + ta), y = h123)) +
+  geom_point() +
+  theme_classic()
+
+ggplot(params, aes(x = log10(tf + ta), y = h2h1)) +
+  geom_point() +
+  theme_classic()
+
+names(params)
+cor(params[,c("tf", "ta", "S", "pi", "thetaw", "tajd", "tajd_var", "tajd_incomplete", "num_haplos", "h1", "h2",  "h12",  "h123", "h2h1", "gkl_var",  "gkl_skew", "gkl_kurt", "zns",  "omega", "hscan")], method = "spearman", use = "pairwise.complete.obs")
+```
+
+# DEPRECATED: PCA
+```{r}
 # get random sample of simulation outputs
 mypics_sub = sample(mypics[(picids %in% params$ID)], size = 1000, replace = F)
 
@@ -450,6 +479,8 @@ for(bin in unique(params$bin)){
     strat_sample = rbind(strat_sample, down_sampled_bin)
  }
 }
+
+table(strat_sample$bin)
 ```
 
 # DEPRECATED: 2D stratified random sampling, along tf and ta

--- a/workflow/rules/slim.smk
+++ b/workflow/rules/slim.smk
@@ -111,7 +111,7 @@ rule slim:
 		"../config/parameters.tsv"
 	output:
 		finalTable=temp("data/tables/slim_{ID}.table"),
-		tmpVCF = temp("slim_{ID}.vcf"),
+		tmpVCF = "slim_{ID}.vcf",
 	log:
 		"logs/slim/{ID}.log"
 	params:

--- a/workflow/scripts/sweep_stats.py
+++ b/workflow/scripts/sweep_stats.py
@@ -259,7 +259,7 @@ def kerns_gkl(gt):
 # average correlation between alleles
 def kellys_zns(gt):
     pair_cor = allel.rogers_huff_r(gt.to_n_alt(fill = -1))
-    mean_cor = numpy.mean(pair_cor**2)
+    mean_cor = numpy.nanmean(pair_cor**2)
     return(mean_cor)
 
 # kims omega, comparing LD within vs between sides of sweep
@@ -286,12 +286,12 @@ def kims_omega(gt):
     right_cor = allel.rogers_huff_r(right_snps)
 
     # convert to coefficient of variation
-    left_cor = numpy.mean(left_cor**2)
-    right_cor = numpy.mean(right_cor**2)
+    left_cor = numpy.nanmean(left_cor**2)
+    right_cor = numpy.nanmean(right_cor**2)
 
     # calculate correlations between variants across groups
     bw_cor = allel.rogers_huff_r_between(left_snps, right_snps)
-    bw_cor = numpy.mean(bw_cor.flatten()**2)
+    bw_cor = numpy.nanmean(bw_cor.flatten()**2)
 
     return((left_cor + right_cor)/bw_cor)
 


### PR DESCRIPTION
After doing two batches of simulations, both hard sweeps but one with constant population size and one with growing population sizes, I realized that I never looked into why Kelley's Zns and Kim's Omega have lots of Nan values. I hypothesized it might be due to the correlation calculation sometimes returning nan values for some variant pairs. 

I don't wanna redo the simulations :(

LD doesn't seem to add too much power to the analyses anyway. It's potentially a good distinguishing factor for very young sweeps but that's it.