### PR TITLE
fix off by one error in window length

### DIFF
--- a/workflow/scripts/sweep_stats.py
+++ b/workflow/scripts/sweep_stats.py
@@ -334,7 +334,7 @@ def hscan(gt, pos, focus):
                     dist_bw_mismatch_focus_below = numpy.min(dist_bw_mismatch_focus)
 
                 length_of_match = numpy.min(dist_bw_mismatch_focus_above) - numpy.max(dist_bw_mismatch_focus_below)
-                results.append( length_of_match/(numpy.max(pos) - numpy.min(pos)) )
+                results.append( length_of_match/(numpy.max(pos) - numpy.min(pos) + 1) )
     return(numpy.mean(results))
 
 # define click options
@@ -381,7 +381,7 @@ def main(vcf, window_length, focus, output_prefix):
     print("Ploidy level: " + str(p))
 
     # calculate window size in bp
-    window_bp = numpy.max(sweep_pos) - numpy.min(sweep_pos)
+    window_bp = numpy.max(sweep_pos) - numpy.min(sweep_pos) + 1
     print(datetime.datetime.now(),"Window size of sweep site in bp:", window_bp)
 
     # calculate statistics


### PR DESCRIPTION
Ugh! Now I found an off-by-one error too! I thought I had scrutinized this a little better, but I think I just got caught up in the rush :( I think there's hope still that at least the off by one error won't affect the sweep statistics that much, with the exception that it should now explain why I was getting INF for pi in windows with 1 variant. For windows with 1 variant I was dividing by a window length of zero.